### PR TITLE
Implement extra Envs and Args feature

### DIFF
--- a/charts/metrics-exporter/templates/deployment.yaml
+++ b/charts/metrics-exporter/templates/deployment.yaml
@@ -40,8 +40,15 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+{{- with .Values.extraEnvs }}
+{{ toYaml . | indent 12 }}
+{{- end }}
           args:
             - -config.file=/config/sql_exporter.yaml
+{{- with .Values.extraArgs }}
+{{ toYaml . | indent 12 }}
+{{- end }}
           ports:
             - name: metrics
               containerPort: {{  get .Values.podAnnotations "prometheus.io/port"  }}


### PR DESCRIPTION
Hi @bueti,
this PR implements additional security measures for providing DB access credentials.
In current implementation those are supposed to be stored as plain text in the config file which might be considered as insecure.
I believe the better way to store credentials is k8s secrets, and then mount it as environment variable:
```
env:
- name: DB_PASSWORD
  valueFrom:
    secretKeyRef:
      name: some-secret
      key: db_password
```
And to provide these credentials to the binary we need an additional argument:
```
container:
- args:
  - -config.file=/config/sql_exporter.yaml
  - -config.data-source-name=sqlserver://db_user:$(DB_PASSWORD)@db_server:1433
```
I hope you will find these changes helpful.
Thanks.